### PR TITLE
Govcloud partition

### DIFF
--- a/eeauditor/auditors/aws/Amazon_SNS_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_SNS_Auditor.py
@@ -99,13 +99,7 @@ def sns_topic_encryption_check(
             finding = {
                 "SchemaVersion": "2018-10-08",
                 "Id": topicarn + "/sns-topic-encryption-check",
-                "ProductArn": "arn:aws:securityhub:"
-                + awsRegion
-                + ":"
-                + awsAccountId
-                + ":product/"
-                + awsAccountId
-                + "/default",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": topicarn,
                 "AwsAccountId": awsAccountId,
                 "Types": [

--- a/eeauditor/auditors/aws/Amazon_SNS_Auditor.py
+++ b/eeauditor/auditors/aws/Amazon_SNS_Auditor.py
@@ -33,14 +33,16 @@ def list_topics(cache):
 
 
 @registry.register_check("sns")
-def sns_topic_encryption_check(cache: dict, awsAccountId: str, awsRegion: str) -> dict:
+def sns_topic_encryption_check(
+    cache: dict, awsAccountId: str, awsRegion: str, awsPartition: str
+) -> dict:
     # loop through SNS topics
     response = list_topics(cache)
     mySnsTopics = response["Topics"]
     iso8601Time = datetime.datetime.now(datetime.timezone.utc).isoformat()
     for topic in mySnsTopics:
         topicarn = str(topic["TopicArn"])
-        topicName = topicarn.replace("arn:aws:sns:" + awsRegion + ":" + awsAccountId + ":", "")
+        topicName = topicarn.replace(f"arn:{awsPartition}:sns:{awsRegion}:{awsAccountId}:", "")
         response = sns.get_topic_attributes(TopicArn=topicarn)
         try:
             # this is a passing check
@@ -48,13 +50,7 @@ def sns_topic_encryption_check(cache: dict, awsAccountId: str, awsRegion: str) -
             finding = {
                 "SchemaVersion": "2018-10-08",
                 "Id": topicarn + "/sns-topic-encryption-check",
-                "ProductArn": "arn:aws:securityhub:"
-                + awsRegion
-                + ":"
-                + awsAccountId
-                + ":product/"
-                + awsAccountId
-                + "/default",
+                "ProductArn": f"arn:{awsPartition}:securityhub:{awsRegion}:{awsAccountId}:product/{awsAccountId}/default",
                 "GeneratorId": topicarn,
                 "AwsAccountId": awsAccountId,
                 "Types": [

--- a/eeauditor/tests/test_Amazon_SNS_Auditor.py
+++ b/eeauditor/tests/test_Amazon_SNS_Auditor.py
@@ -82,17 +82,28 @@ def test_sns_topic_no_encryption(sns_stubber):
     for result in results:
         assert result["RecordState"] == "ACTIVE"
         assert result["Title"] == "[SNS.1] SNS topics should be encrypted"
+        assert (
+            result["ProductArn"]
+            == "arn:aws:securityhub:us-east-1:012345678901:product/012345678901/default"
+        )
 
 
-def test_sns_topic_encryption(sns_stubber):
+def test_sns_topic_encryption_gov(sns_stubber):
     sns_stubber.add_response("list_topics", list_topics_response)
     sns_stubber.add_response("get_topic_attributes", get_topic_attributes_kms_response)
     results = sns_topic_encryption_check(
-        cache={}, awsAccountId="012345678901", awsRegion="us-east-1", awsPartition="aws"
+        cache={},
+        awsAccountId="012345678901",
+        awsRegion="us-gov-east-1",
+        awsPartition="aws-us-gov",
     )
     for result in results:
         assert result["RecordState"] == "ARCHIVED"
         assert result["Title"] == "[SNS.1] SNS topics should be encrypted"
+        assert (
+            result["ProductArn"]
+            == "arn:aws-us-gov:securityhub:us-gov-east-1:012345678901:product/012345678901/default"
+        )
 
 
 def test_id_arn_is_principal(sns_stubber):


### PR DESCRIPTION
This is a proposal to support govcloud in the same checks by passing a partition parameter to the auditor checks.  This is a very small change to each auditor. 

NOTE: As this is currently just a proposal, I have only updated one check in one auditor: `sns_topic_encryption_check` and have not updated the eeauditor.py statement that calls the checks.